### PR TITLE
Avoid value change warning

### DIFF
--- a/NEON_2_SSE.h
+++ b/NEON_2_SSE.h
@@ -5454,7 +5454,7 @@ _NEON2SSE_INLINE uint8x16_t vcgtq_u8(uint8x16_t a, uint8x16_t b) // VCGT.U8 q0, 
 {
       //no unsigned chars comparison, only signed available,so need the trick
         __m128i c128, as, bs;
-        c128 = _mm_set1_epi8(128);
+        c128 = _mm_set1_epi8(0x80);
         as = _mm_sub_epi8(a, c128);
         bs = _mm_sub_epi8(b, c128);
         return _mm_cmpgt_epi8(as, bs);


### PR DESCRIPTION
This fixes (closed but apparently unresolved) issue #27 "warning: implicit conversion from 'int' to 'char' changes value from 128 to -128"