### PR TITLE
Add vqtbl1q_?8 intrinsics

### DIFF
--- a/NEON_2_SSE.h
+++ b/NEON_2_SSE.h
@@ -1819,6 +1819,9 @@ _NEON2SSESTORAGE uint32x2_t vqmovun_s64(int64x2_t a); // VQMOVUN.S64 d0,q0
 _NEON2SSESTORAGE uint8x8_t vtbl1_u8(uint8x8_t a, uint8x8_t b); // VTBL.8 d0, {d0}, d0
 _NEON2SSESTORAGE int8x8_t vtbl1_s8(int8x8_t a, int8x8_t b); // VTBL.8 d0, {d0}, d0
 _NEON2SSESTORAGE poly8x8_t vtbl1_p8(poly8x8_t a, uint8x8_t b); // VTBL.8 d0, {d0}, d0
+_NEON2SSESTORAGE uint8x16_t vqtbl1q_u8(uint8x16_t a, uint8x16_t b); // VQTBL.16 q0, {q0}, q0
+_NEON2SSESTORAGE int8x16_t vqtbl1q_s8(int8x16_t a, uint8x16_t b); // VQTBL.16 q0, {q0}, q0
+_NEON2SSESTORAGE poly8x16_t vqtbl1q_p8(poly8x16_t a, uint8x16_t b); // VQTBL.16 q0, {q0}, q0
 //Extended table look up intrinsics
 _NEON2SSESTORAGE uint8x8_t vtbx1_u8(uint8x8_t a, uint8x8_t b, uint8x8_t c); // VTBX.8 d0, {d0}, d0
 _NEON2SSESTORAGE int8x8_t vtbx1_s8(int8x8_t a, int8x8_t b, int8x8_t c); // VTBX.8 d0, {d0}, d0
@@ -13178,6 +13181,22 @@ _NEON2SSESTORAGE int8x8_t vtbl1_s8(int8x8_t a,  int8x8_t b); // VTBL.8 d0, {d0},
 
 _NEON2SSESTORAGE poly8x8_t vtbl1_p8(poly8x8_t a, uint8x8_t b); // VTBL.8 d0, {d0}, d0
 #define vtbl1_p8 vtbl1_u8
+
+_NEON2SSESTORAGE uint8x16_t vqtbl1q_u8(uint8x16_t a, uint8x16_t b); // VQTBL.16 q0, {q0}, q0
+_NEON2SSE_INLINE uint8x16_t vqtbl1q_u8(uint8x16_t a, uint8x16_t b)
+{
+    __m128i c15, maskgt, bmask;
+    c15 = _mm_set1_epi8(15);
+    maskgt = _mm_cmpgt_epi8(b, c15);
+    bmask = _mm_or_si128(b, maskgt);
+    return _mm_shuffle_epi8(a, bmask);
+}
+
+_NEON2SSESTORAGE int8x16_t vqtbl1q_s8(int8x16_t a, uint8x16_t b); // VQTBL.16 q0, {q0}, q0
+#define vqtbl1q_s8 vqtbl1q_u8
+
+_NEON2SSESTORAGE poly8x16_t vqtbl1q_p8(poly8x16_t a, uint8x16_t b); // VQTBL.16 q0, {q0}, q0
+#define vqtbl1q_p8 vqtbl1q_u8
 
 _NEON2SSESTORAGE uint8x8_t vtbl2_u8(uint8x8x2_t a, uint8x8_t b); // VTBL.8 d0, {d0, d1}, d0
 _NEON2SSE_INLINE uint8x8_t vtbl2_u8(uint8x8x2_t a, uint8x8_t b)


### PR DESCRIPTION
Add vqtbl1q_?8 intrinsics.
This partially fixes issue #33 "The vqtbl* intrinsics are missing".
If you accept this patch I could try to add other vqtbl* intrinsics.