### PR TITLE
Fix cmake languages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Modification: Copyright (C) 2017 David Hirvonen
 
 cmake_minimum_required(VERSION 3.0)
-project(NEON_2_SSE VERSION 1.0.0)
+project(NEON_2_SSE VERSION 1.0.0 LANGUAGES C)
 
 add_library(${PROJECT_NAME} INTERFACE)
 


### PR DESCRIPTION
When no language is set cmake defaults to `C` and `CXX`, since we support `C` by itself we should set the project language to `C` so that we don't get a compiler error when building without a `CXX` toolchain.

Fixes:
```
CMake Error at CMakeLists.txt:5 (project):
  No CMAKE_CXX_COMPILER could be found.

  Tell CMake where to find the compiler by setting either the environment
  variable "CXX" or the CMake cache entry CMAKE_CXX_COMPILER to the full path
  to the compiler, or to the compiler name if it is in the PATH.
```