### PR TITLE
Add missing definition of _NEON2SSE_ALIGN_32 for gcc / clang

### DIFF
--- a/NEON_2_SSE.h
+++ b/NEON_2_SSE.h
@@ -85,6 +85,7 @@
 #   define _GCC_VERSION (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
 #   define _NEON2SSESTORAGE static
 #   define _NEON2SSE_ALIGN_16  __attribute__((aligned(16)))
+#   define _NEON2SSE_ALIGN_32  __attribute__((aligned(32)))
 #   ifdef __clang__
 #       define _NEON2SSE_INLINE _NEON2SSESTORAGE inline __attribute__((__gnu_inline__, __always_inline__))
 #   else


### PR DESCRIPTION
Fixes:
```
contrib/libs/arm_neon_2_x86_sse/NEON_2_SSE.h:467:1: error: unknown type name '_NEON2SSE_ALIGN_32'
_NEON2SSE_ALIGN_32 static const int8_t mask8_16_even_odd[32] = ...
```