### PR TITLE
Add Compatibility for CMake 4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Boilerplate: Copyright (C) 2014-2017 Ruslan Baratov
 # Modification: Copyright (C) 2017 David Hirvonen
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(NEON_2_SSE VERSION 1.0.0 LANGUAGES C)
 
 add_library(${PROJECT_NAME} INTERFACE)


### PR DESCRIPTION
This patch adds compatibility for CMake 4. CMake 4 drops support for projects that set a minimum requirement of less than 3.5. That version of CMake was released almost ten years ago, so this should not have any practical effects on software support while enabling support for more recent CMake versions.

Signed-off-by: Aiden Grossman <aidengrossman@google.com>