### PR TITLE
add vtrn1q_f32 vtrn2q_f32 function

### DIFF
--- a/NEON_2_SSE.h
+++ b/NEON_2_SSE.h
@@ -2265,6 +2265,8 @@ _NEON2SSE_GLOBAL uint8x16x2_t vtrnq_u8(uint8x16_t a, uint8x16_t b); // VTRN.8 q0
 _NEON2SSE_GLOBAL uint16x8x2_t vtrnq_u16(uint16x8_t a, uint16x8_t b); // VTRN.16 q0,q0
 _NEON2SSE_GLOBAL uint32x4x2_t vtrnq_u32(uint32x4_t a, uint32x4_t b); // VTRN.32 q0,q0
 _NEON2SSESTORAGE float32x4x2_t vtrnq_f32(float32x4_t a, float32x4_t b); // VTRN.32 q0,q0
+_NEON2SSESTORAGE float32x4_t vtrn1q_f32(float32x4_t a, float32x4_t b); // VTRN.32 d0,d0
+_NEON2SSESTORAGE float32x4_t vtrn2q_f32(float32x4_t a, float32x4_t b); // VTRN.32 d0,d0
 _NEON2SSE_GLOBAL poly8x16x2_t vtrnq_p8(poly8x16_t a, poly8x16_t b); // VTRN.8 q0,q0
 _NEON2SSE_GLOBAL poly16x8x2_t vtrnq_p16(poly16x8_t a, poly16x8_t b); // VTRN.16 q0,q0
 //Interleave elements
@@ -16018,6 +16020,32 @@ _NEON2SSE_INLINE float32x4x2_t vtrnq_f32(float32x4_t a, float32x4_t b) // VTRN.3
 
     f32x4.val[0] = _mm_unpacklo_ps(a_sh, b_sh); //a0, b0, a2, b2
     f32x4.val[1] = _mm_unpackhi_ps(a_sh, b_sh); //a1, b1, a3,  b3
+    return f32x4;
+}
+
+_NEON2SSESTORAGE float32x4_t vtrn1q_f32(float32x4_t a, float32x4_t b); // VTRN.32 d0,d0
+_NEON2SSE_INLINE float32x4_t vtrn1q_f32(float32x4_t a, float32x4_t b)
+{
+    //may be not optimal solution compared with serial
+    float32x4_t f32x4;
+    __m128 a_sh, b_sh;
+    a_sh = _mm_shuffle_ps (a, a, _MM_SHUFFLE(3,1, 2, 0)); //a0, a2, a1, a3, need to check endiness
+    b_sh = _mm_shuffle_ps (b, b, _MM_SHUFFLE(3,1, 2, 0)); //b0, b2, b1, b3, need to check endiness
+
+    f32x4 = _mm_unpacklo_ps(a_sh, b_sh); //a0, b0, a2, b2
+    return f32x4;
+}
+
+_NEON2SSESTORAGE float32x4_t vtrn2q_f32(float32x4_t a, float32x4_t b); // VTRN.32 d0,d0
+_NEON2SSE_INLINE float32x4_t vtrn2q_f32(float32x4_t a, float32x4_t b)
+{
+    //may be not optimal solution compared with serial
+    float32x4_t f32x4;
+    __m128 a_sh, b_sh;
+    a_sh = _mm_shuffle_ps (a, a, _MM_SHUFFLE(3,1, 2, 0)); //a0, a2, a1, a3, need to check endiness
+    b_sh = _mm_shuffle_ps (b, b, _MM_SHUFFLE(3,1, 2, 0)); //b0, b2, b1, b3, need to check endiness
+
+    f32x4 = _mm_unpackhi_ps(a_sh, b_sh); //a1, b1, a3,  b3
     return f32x4;
 }
 


### PR DESCRIPTION
the main cpp should add vtrn1q_f32 and vtrn2q_f32 function

[https://developer.arm.com/architectures/instruction-sets/intrinsics/vtrn1q_f32](https://developer.arm.com/architectures/instruction-sets/intrinsics/vtrn1q_f32)

[https://developer.arm.com/architectures/instruction-sets/intrinsics/vtrn2q_f32](https://developer.arm.com/architectures/instruction-sets/intrinsics/vtrn2q_f32)

[https://developer.arm.com/architectures/instruction-sets/intrinsics/vtrnq_f32](https://developer.arm.com/architectures/instruction-sets/intrinsics/vtrnq_f32)

test.cpp，this code is used for testing vtrn1q_f32 vtrn2q_f32 function

compile "g++ test.cpp -o test -I./"

```C++
// https://github.com/intel/ARM_NEON_2_x86_SSE

#include<iostream>
#include <NEON_2_SSE.h>
using namespace std;

static inline float combine_neon()
{
    // 修复：不用临时数组，vsetq装填
    float32x4_t v, v_rev;
    v = vsetq_lane_f32(1, v, 0);
    v = vsetq_lane_f32(2, v, 1);
    v = vsetq_lane_f32(3, v, 2);
    v = vsetq_lane_f32(6, v, 3);

    v_rev = vsetq_lane_f32(11, v_rev, 0);
    v_rev = vsetq_lane_f32(22, v_rev, 1);
    v_rev = vsetq_lane_f32(33, v_rev, 2);
    v_rev = vsetq_lane_f32(66, v_rev, 3);
    float32x4_t v_shuf = vtrn1q_f32(v, v_rev);
    float32x4_t v_shuf2 = vtrn2q_f32(v, v_rev);

    float va = vgetq_lane_f32(v_shuf, 0);
    float vb = vgetq_lane_f32(v_shuf, 1);
    float vc = vgetq_lane_f32(v_shuf, 2);
    float vd = vgetq_lane_f32(v_shuf, 3);

    float va1 = vgetq_lane_f32(v_shuf2, 0);
    float vb1 = vgetq_lane_f32(v_shuf2, 1);
    float vc1 = vgetq_lane_f32(v_shuf2, 2);
    float vd1 = vgetq_lane_f32(v_shuf2, 3);

    std::cout << va << " " << vb <<" " << vc <<" " << vd<<std::endl;
    std::cout << va1 << " " << vb1 <<" " << vc1 <<" " << vd1<<std::endl;
    
    return vc;
}

int main(void)
{
    combine_neon();
    return 0;
}
```